### PR TITLE
fix: parentElement changed to parentNode because of IE 11 issues

### DIFF
--- a/packages/slate-react/src/components/editable.tsx
+++ b/packages/slate-react/src/components/editable.tsx
@@ -163,7 +163,7 @@ export const Editable = (props: EditableProps) => {
 
     if (newDomRange) {
       domSelection.addRange(newDomRange!)
-      const leafEl = newDomRange.startContainer.parentElement!
+      const leafEl = newDomRange.startContainer.parentNode!
       scrollIntoView(leafEl, { scrollMode: 'if-needed' })
     }
 

--- a/packages/slate-react/src/components/editable.tsx
+++ b/packages/slate-react/src/components/editable.tsx
@@ -163,7 +163,7 @@ export const Editable = (props: EditableProps) => {
 
     if (newDomRange) {
       domSelection.addRange(newDomRange!)
-      const leafEl = newDomRange.startContainer.parentNode!
+      const leafEl = newDomRange.startContainer.parentNode! as HTMLElement
       scrollIntoView(leafEl, { scrollMode: 'if-needed' })
     }
 

--- a/packages/slate-react/src/plugin/react-editor.ts
+++ b/packages/slate-react/src/plugin/react-editor.ts
@@ -296,10 +296,10 @@ export const ReactEditor = {
    */
 
   toSlateNode(editor: ReactEditor, domNode: DOMNode): Node {
-    let domEl = isDOMElement(domNode) ? domNode : domNode.parentNode
+    let domEl = isDOMElement(domNode) ? domNode : domNode.parentNode as HTMLElement
 
     if (domEl && !domEl.hasAttribute('data-slate-node')) {
-      domEl = domEl.closest(`[data-slate-node]`)
+      domEl = domEl.closest(`[data-slate-node]`) as HTMLElement
     }
 
     const node = domEl ? ELEMENT_TO_NODE.get(domEl as HTMLElement) : null

--- a/packages/slate-react/src/plugin/react-editor.ts
+++ b/packages/slate-react/src/plugin/react-editor.ts
@@ -159,7 +159,7 @@ export const ReactEditor = {
     try {
       targetEl = (isDOMElement(target)
         ? target
-        : target.parentElement) as HTMLElement
+        : target.parentNode) as HTMLElement
     } catch (err) {
       if (
         !err.message.includes('Permission denied to access property "nodeType"')
@@ -279,11 +279,11 @@ export const ReactEditor = {
     // adjust the offset accordingly.
     const startEl = (isDOMElement(startNode)
       ? startNode
-      : startNode.parentElement) as HTMLElement
+      : startNode.parentNode) as HTMLElement
     const isStartAtZeroWidth = !!startEl.getAttribute('data-slate-zero-width')
     const endEl = (isDOMElement(endNode)
       ? endNode
-      : endNode.parentElement) as HTMLElement
+      : endNode.parentNode) as HTMLElement
     const isEndAtZeroWidth = !!endEl.getAttribute('data-slate-zero-width')
 
     domRange.setStart(startNode, isStartAtZeroWidth ? 1 : startOffset)
@@ -296,7 +296,7 @@ export const ReactEditor = {
    */
 
   toSlateNode(editor: ReactEditor, domNode: DOMNode): Node {
-    let domEl = isDOMElement(domNode) ? domNode : domNode.parentElement
+    let domEl = isDOMElement(domNode) ? domNode : domNode.parentNode
 
     if (domEl && !domEl.hasAttribute('data-slate-node')) {
       domEl = domEl.closest(`[data-slate-node]`)


### PR DESCRIPTION
####  _bug_

Calling `parentElement` from `textNode` returns undefined in IE11, so IE11 crushes. For example it crushes in on `scrollIntoView` from 'scroll-into-view-if-needed' because `target` is `undefined`
```
!target.ownerDocument.documentElement.contains(target);
```

#### What's the new behavior?

This PR changes `parentElement` to more stable `parentElement`


#### Have you checked that...?

- [x] The new code matches the existing patterns and styles.
- [x] The tests pass with `yarn test`.
- [x] The linter passes with `yarn lint`. (Fix errors with `yarn fix`.)
- [x] The relevant examples still work. (Run examples with `yarn start`.)


